### PR TITLE
correct perm for systemd executing smart-proxy

### DIFF
--- a/61-foreman-proxy.rules
+++ b/61-foreman-proxy.rules
@@ -1,2 +1,2 @@
 allow perm=open exe=/usr/bin/ruby : dir=/usr/share/gems ftype=text/x-ruby trust=0
-allow perm=all exe=/usr/lib/systemd/systemd : dir=/usr/share/foreman-proxy/bin/smart-proxy ftype=text/x-ruby trust=0
+allow perm=any exe=/usr/lib/systemd/systemd : dir=/usr/share/foreman-proxy/bin/smart-proxy ftype=text/x-ruby trust=0


### PR DESCRIPTION
It's `perm=any`, not `perm=all`, otherwise you get errors like:

    Access permission (all) is unknown in line 13