### PR TITLE
Add rule to work around failure with containers

### DIFF
--- a/15-foreman-container.rules
+++ b/15-foreman-container.rules
@@ -1,0 +1,3 @@
+# This is needed to work around a bug in RHEL fapolicyd rules for containers
+# See https://issues.redhat.com/browse/RHEL-37912
+allow perm=any pattern=ld_so exe=/usr/bin/crun : path=/usr/lib64/libsystemd.so.0


### PR DESCRIPTION
This is needed for quadlets, such as iop containers, when using fapolicyd to work around a RHEL bug:

https://issues.redhat.com/browse/RHEL-37912