### PR TITLE
Add Packit commit trigger job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,10 +19,17 @@ actions:
   get-current-version: "cat VERSION"
 
 jobs:
-  - job: copr_build
+  - &copr
+    job: copr_build
     trigger: pull_request
     targets:
       - rhel-9
+
+  - <<: *copr
+    trigger: commit
+    branch: develop
+    owner: '@theforeman'
+    project: develop
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
This PR adds a second Packit job that triggers on commits to the default branch.

The new job:
- Inherits configuration from the existing pull_request job using YAML anchors
- Triggers on commits to the default branch
- Builds in the @theforeman/develop COPR project
- Uses the same targets and configuration as PR builds

This enables automated COPR builds on commits, making it easier to test changes from the development branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)